### PR TITLE
Mock WordPress functions in spec

### DIFF
--- a/spec/WPUpdatePhpSpec.php
+++ b/spec/WPUpdatePhpSpec.php
@@ -1,24 +1,31 @@
 <?php
 
-namespace spec;
-
-use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
-
-class WPUpdatePhpSpec extends ObjectBehavior
-{
-    function let()
-    {
-        $this->beConstructedWith('5.4.0');
+namespace {
+    function add_action( $hook, $callback ) {
+        return true;
     }
 
-    function it_can_run_on_minimum_version()
-    {
-        $this->does_it_meet_required_php_version('5.4.0')->shouldReturn(true);
+    function is_admin() {
+        return true;
     }
+}
 
-    function it_will_not_run_on_old_version()
-    {
-        $this->does_it_meet_required_php_version('5.2.4')->shouldReturn(false);
+namespace spec {
+
+    use PhpSpec\ObjectBehavior;
+    use Prophecy\Argument;
+
+    class WPUpdatePhpSpec extends ObjectBehavior {
+        function let() {
+            $this->beConstructedWith( '5.4.0' );
+        }
+
+        function it_can_run_on_minimum_version() {
+            $this->does_it_meet_required_php_version( '5.4.0' )->shouldReturn( true );
+        }
+
+        function it_will_not_run_on_old_version() {
+            $this->does_it_meet_required_php_version( '5.2.4' )->shouldReturn( false );
+        }
     }
 }

--- a/src/WPUpdatePhp.php
+++ b/src/WPUpdatePhp.php
@@ -38,12 +38,6 @@ class WPUpdatePhp {
 	 * @return void
 	 */
 	private function load_minimum_required_version_notice() {
-		// Check if this code is being run inside WordPress, because the tests will not have
-		// this function for example. This function is always available inside WordPress.
-		if ( ! function_exists( 'is_admin' ) ) {
-			return;
-		}
-
 		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
 			add_action( 'admin_notices', array( $this, 'admin_notice' ) );
 		}


### PR DESCRIPTION
This removes the need to check if these functions exist, before calling them, for when they are used in the specs. They will always be available when this is called inside WordPress.

@dannyvankooten Are you happy with this, or should I mock them in a different way? I don't like the way I have to break namespaces in the spec now, but if that's the only issue, then I'll get used to it.
