### PR TITLE
Optional recommended version notice

### DIFF
--- a/spec/WPUpdatePhpSpec.php
+++ b/spec/WPUpdatePhpSpec.php
@@ -17,15 +17,23 @@ namespace spec {
 
     class WPUpdatePhpSpec extends ObjectBehavior {
         function let() {
-            $this->beConstructedWith( '5.4.0' );
+            $this->beConstructedWith( '5.4.0', '5.3.0' );
         }
 
         function it_can_run_on_minimum_version() {
             $this->does_it_meet_required_php_version( '5.4.0' )->shouldReturn( true );
         }
 
+        function it_passes_the_recommended_version() {
+            $this->does_it_meet_recommended_php_version( '5.3.0' )->shouldReturn( true );
+        }
+
         function it_will_not_run_on_old_version() {
             $this->does_it_meet_required_php_version( '5.2.4' )->shouldReturn( false );
+        }
+
+        function it_fails_the_recommended_version() {
+            $this->does_it_meet_recommended_php_version( '5.2.9' )->shouldReturn( false );
         }
     }
 }

--- a/src/WPUpdatePhp.php
+++ b/src/WPUpdatePhp.php
@@ -53,13 +53,28 @@ class WPUpdatePhp {
 	 */
 	private function load_minimum_required_version_notice() {
 		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
-			add_action( 'admin_notices', array( $this, 'admin_notice' ) );
+			add_action( 'admin_notices', array( $this, 'minimum_admin_notice' ) );
 		}
 	}
 
-	public function admin_notice() {
+	public function minimum_admin_notice() {
 		echo '<div class="error">';
 		echo '<p>Unfortunately, this plugin can not run on PHP versions older than '. $this->minimum_version .'. Read more information about <a href="http://www.wpupdatephp.com/update/">how you can update</a>.</p>';
+		echo '</div>';
+	}
+
+	/**
+	 * @return void
+	 */
+	private function load_recommended_required_version_notice() {
+		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
+			add_action( 'admin_notices', array( $this, 'recommended_admin_notice' ) );
+		}
+	}
+
+	public function recommended_admin_notice() {
+		echo '<div class="error">';
+		echo '<p>This plugin recommends a PHP versions older than '. $this->recommended_version .'. Read more information about <a href="http://www.wpupdatephp.com/update/">how you can update</a>.</p>';
 		echo '</div>';
 	}
 }

--- a/src/WPUpdatePhp.php
+++ b/src/WPUpdatePhp.php
@@ -4,11 +4,16 @@ class WPUpdatePhp {
 	/** @var String */
 	private $minimum_version;
 
+	/** @var String */
+	private $recommended_version;
+
 	/**
-	 * @param $minimum_version
+	 * @param      $minimum_version
+	 * @param null $recommended_version
 	 */
-	public function __construct( $minimum_version ) {
+	public function __construct( $minimum_version, $recommended_version = null ) {
 		$this->minimum_version = $minimum_version;
+		$this->recommended_version = $recommended_version;
 	}
 
 	/**

--- a/src/WPUpdatePhp.php
+++ b/src/WPUpdatePhp.php
@@ -33,6 +33,20 @@ class WPUpdatePhp {
 	/**
 	 * @param $version
 	 *
+	 * @return bool
+	 */
+	public function does_it_meet_recommended_php_version( $version ) {
+		if ( $this->is_recommended_php_version( $version ) ) {
+			return true;
+		}
+
+		$this->load_recommended_required_version_notice();
+		return false;
+	}
+
+	/**
+	 * @param $version
+	 *
 	 * @return boolean
 	 */
 	private function is_minimum_php_version( $version ) {

--- a/src/WPUpdatePhp.php
+++ b/src/WPUpdatePhp.php
@@ -40,6 +40,15 @@ class WPUpdatePhp {
 	}
 
 	/**
+	 * @param $version
+	 *
+	 * @return boolean
+	 */
+	private function is_recommended_php_version( $version ) {
+		return version_compare( $this->recommended_version, $version, '<=' );
+	}
+
+	/**
 	 * @return void
 	 */
 	private function load_minimum_required_version_notice() {

--- a/src/WPUpdatePhp.php
+++ b/src/WPUpdatePhp.php
@@ -21,7 +21,7 @@ class WPUpdatePhp {
 	 *
 	 * @return bool
 	 */
-	public function does_it_meet_required_php_version( $version ) {
+	public function does_it_meet_required_php_version( $version = PHP_VERSION ) {
 		if ( $this->version_passes_requirement( $this->minimum_version, $version ) ) {
 			return true;
 		}
@@ -35,7 +35,7 @@ class WPUpdatePhp {
 	 *
 	 * @return bool
 	 */
-	public function does_it_meet_recommended_php_version( $version ) {
+	public function does_it_meet_recommended_php_version( $version = PHP_VERSION ) {
 		if ( $this->version_passes_requirement( $this->recommended_version, $version ) ) {
 			return true;
 		}

--- a/src/WPUpdatePhp.php
+++ b/src/WPUpdatePhp.php
@@ -22,7 +22,7 @@ class WPUpdatePhp {
 	 * @return bool
 	 */
 	public function does_it_meet_required_php_version( $version ) {
-		if ( $this->is_minimum_php_version( $version ) ) {
+		if ( $this->version_passes_requirement( $this->minimum_version, $version ) ) {
 			return true;
 		}
 
@@ -36,7 +36,7 @@ class WPUpdatePhp {
 	 * @return bool
 	 */
 	public function does_it_meet_recommended_php_version( $version ) {
-		if ( $this->is_recommended_php_version( $version ) ) {
+		if ( $this->version_passes_requirement( $this->recommended_version, $version ) ) {
 			return true;
 		}
 
@@ -45,21 +45,13 @@ class WPUpdatePhp {
 	}
 
 	/**
+	 * @param $requirement
 	 * @param $version
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
-	private function is_minimum_php_version( $version ) {
-		return version_compare( $this->minimum_version, $version, '<=' );
-	}
-
-	/**
-	 * @param $version
-	 *
-	 * @return boolean
-	 */
-	private function is_recommended_php_version( $version ) {
-		return version_compare( $this->recommended_version, $version, '<=' );
+	private function version_passes_requirement( $requirement, $version ) {
+		return version_compare( $requirement, $version, '<=' );
 	}
 
 	/**

--- a/src/WPUpdatePhp.php
+++ b/src/WPUpdatePhp.php
@@ -26,7 +26,7 @@ class WPUpdatePhp {
 			return true;
 		}
 
-		$this->load_minimum_required_version_notice();
+		$this->load_version_notice( array( $this, 'minimum_admin_notice' ) );
 		return false;
 	}
 
@@ -40,7 +40,7 @@ class WPUpdatePhp {
 			return true;
 		}
 
-		$this->load_recommended_required_version_notice();
+		$this->load_version_notice( array( $this, 'recommended_admin_notice' ) );
 		return false;
 	}
 
@@ -55,11 +55,13 @@ class WPUpdatePhp {
 	}
 
 	/**
+	 * @param $callback
+	 *
 	 * @return void
 	 */
-	private function load_minimum_required_version_notice() {
+	private function load_version_notice( $callback ) {
 		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
-			add_action( 'admin_notices', array( $this, 'minimum_admin_notice' ) );
+			add_action( 'admin_notices', $callback );
 		}
 	}
 
@@ -67,15 +69,6 @@ class WPUpdatePhp {
 		echo '<div class="error">';
 		echo '<p>Unfortunately, this plugin can not run on PHP versions older than '. $this->minimum_version .'. Read more information about <a href="http://www.wpupdatephp.com/update/">how you can update</a>.</p>';
 		echo '</div>';
-	}
-
-	/**
-	 * @return void
-	 */
-	private function load_recommended_required_version_notice() {
-		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
-			add_action( 'admin_notices', array( $this, 'recommended_admin_notice' ) );
-		}
 	}
 
 	public function recommended_admin_notice() {

--- a/src/WPUpdatePhp.php
+++ b/src/WPUpdatePhp.php
@@ -73,7 +73,7 @@ class WPUpdatePhp {
 
 	public function recommended_admin_notice() {
 		echo '<div class="error">';
-		echo '<p>This plugin recommends a PHP versions older than '. $this->recommended_version .'. Read more information about <a href="http://www.wpupdatephp.com/update/">how you can update</a>.</p>';
+		echo '<p>This plugin recommends a PHP versions higher than '. $this->recommended_version .'. Read more information about <a href="http://www.wpupdatephp.com/update/">how you can update</a>.</p>';
 		echo '</div>';
 	}
 }


### PR DESCRIPTION
My first attempt at solving #2.

Accept a second optional parameter as the recommended version for your plugin. This to allow plugin developers to recommend users of the plugin to ask their hosting company to upgrade their hosting package to whatever version of PHP that you would like to require.
