### PR TITLE
Use GPL-2.0+ license

### DIFF
--- a/src/WPUpdatePhp.php
+++ b/src/WPUpdatePhp.php
@@ -5,7 +5,7 @@
  *
  * @package   WPUpdatePhp
  * @author    Coen Jacobs
- * @license   GPLv3
+ * @license   GPL-2.0+
  * @link      https://github.com/WPupdatePHP/wp-update-php
  */
 


### PR DESCRIPTION
My understanding of licensing may well be suspect, but if you use v3, then developers who have a system that include GPL 2.0-only plugins, can't use plugins that have wp-update-php as a dependency.

Stick to the same as core (GPL-2.0+) and it's easier to see that everyone plays nice together.
