### PR TITLE
Notices refactor to multiple classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For example, when you start your plugin by instantiating a new object, you shoul
 _Example:_
 
 ```php
-$updatePhp = new WPUpdatePhp( '5.4.0' );
+$updatePhp = new WPUpdatePhp( '5.6.0' );
 
 if ( $updatePhp->does_it_meet_required_php_version() ) {
     // Instantiate new object here

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,0 +1,1 @@
+bootstrap: spec/bootstrap.php

--- a/spec/WPUP/Minimum/NoticeSpec.php
+++ b/spec/WPUP/Minimum/NoticeSpec.php
@@ -1,11 +1,5 @@
 <?php
 
-namespace {
-    function esc_url( $string ) {
-        return $string;
-    }
-}
-
 namespace spec {
 
     use PhpSpec\ObjectBehavior;

--- a/spec/WPUP/Minimum/NoticeSpec.php
+++ b/spec/WPUP/Minimum/NoticeSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace {
+    function esc_url( $string ) {
+        return $string;
+    }
+}
+
+namespace spec {
+
+    use PhpSpec\ObjectBehavior;
+
+    class WPUP_Minimum_NoticeSpec extends ObjectBehavior
+    {
+        function let()
+        {
+            $this->beConstructedWith('5.4.0', 'Test Plugin');
+        }
+
+        function it_adds_plugin_name_to_admin_notice()
+        {
+            $this->getNoticeText()->shouldMatch('/Test Plugin/i');
+        }
+    }
+}

--- a/spec/WPUP/Minimum/NoticeSpec.php
+++ b/spec/WPUP/Minimum/NoticeSpec.php
@@ -1,19 +1,18 @@
 <?php
 
-namespace spec {
+namespace spec;
 
-    use PhpSpec\ObjectBehavior;
+use PhpSpec\ObjectBehavior;
 
-    class WPUP_Minimum_NoticeSpec extends ObjectBehavior
+class WPUP_Minimum_NoticeSpec extends ObjectBehavior
+{
+    function let()
     {
-        function let()
-        {
-            $this->beConstructedWith('5.4.0', 'Test Plugin');
-        }
+        $this->beConstructedWith('5.4.0', 'Test Plugin');
+    }
 
-        function it_adds_plugin_name_to_admin_notice()
-        {
-            $this->getNoticeText()->shouldMatch('/Test Plugin/i');
-        }
+    function it_adds_plugin_name_to_admin_notice()
+    {
+        $this->getNoticeText()->shouldMatch('/Test Plugin/i');
     }
 }

--- a/spec/WPUP/Recommended/NoticeSpec.php
+++ b/spec/WPUP/Recommended/NoticeSpec.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace spec {
+
+    use PhpSpec\ObjectBehavior;
+
+    class WPUP_Recommended_NoticeSpec extends ObjectBehavior
+    {
+        function let()
+        {
+            $this->beConstructedWith('5.4.0', 'Test Plugin');
+        }
+
+        function it_adds_plugin_name_to_admin_notice()
+        {
+            $this->getNoticeText()->shouldMatch('/Test Plugin/i');
+        }
+    }
+}

--- a/spec/WPUP/Recommended/NoticeSpec.php
+++ b/spec/WPUP/Recommended/NoticeSpec.php
@@ -1,19 +1,18 @@
 <?php
 
-namespace spec {
+namespace spec;
 
-    use PhpSpec\ObjectBehavior;
+use PhpSpec\ObjectBehavior;
 
-    class WPUP_Recommended_NoticeSpec extends ObjectBehavior
+class WPUP_Recommended_NoticeSpec extends ObjectBehavior
+{
+    function let()
     {
-        function let()
-        {
-            $this->beConstructedWith('5.4.0', 'Test Plugin');
-        }
+        $this->beConstructedWith('5.4.0', 'Test Plugin');
+    }
 
-        function it_adds_plugin_name_to_admin_notice()
-        {
-            $this->getNoticeText()->shouldMatch('/Test Plugin/i');
-        }
+    function it_adds_plugin_name_to_admin_notice()
+    {
+        $this->getNoticeText()->shouldMatch('/Test Plugin/i');
     }
 }

--- a/spec/WPUpdatePhpSpec.php
+++ b/spec/WPUpdatePhpSpec.php
@@ -13,7 +13,6 @@ namespace {
 namespace spec {
 
     use PhpSpec\ObjectBehavior;
-    use Prophecy\Argument;
 
     class WPUpdatePhpSpec extends ObjectBehavior {
         function let() {
@@ -35,11 +34,5 @@ namespace spec {
         function it_fails_the_recommended_version() {
             $this->does_it_meet_recommended_php_version( '5.2.9' )->shouldReturn( false );
         }
-
-	    function it_adds_plugin_name_to_admin_notice() {
-		    $this->set_plugin_name( 'Test Plugin' );
-		    $this->get_admin_notice()->shouldMatch('/Test Plugin/i');
-		    $this->get_admin_notice( 'recommended' )->shouldMatch('/Test Plugin/i');
-	    }
     }
 }

--- a/spec/WPUpdatePhpSpec.php
+++ b/spec/WPUpdatePhpSpec.php
@@ -1,15 +1,5 @@
 <?php
 
-namespace {
-    function add_action( $hook, $callback ) {
-        return true;
-    }
-
-    function is_admin() {
-        return true;
-    }
-}
-
 namespace spec {
 
     use PhpSpec\ObjectBehavior;

--- a/spec/WPUpdatePhpSpec.php
+++ b/spec/WPUpdatePhpSpec.php
@@ -1,28 +1,27 @@
 <?php
 
-namespace spec {
+namespace spec;
 
-    use PhpSpec\ObjectBehavior;
+use PhpSpec\ObjectBehavior;
 
-    class WPUpdatePhpSpec extends ObjectBehavior {
-        function let() {
-            $this->beConstructedWith( '5.4.0', '5.3.0' );
-        }
+class WPUpdatePhpSpec extends ObjectBehavior {
+    function let() {
+        $this->beConstructedWith( '5.4.0', '5.3.0' );
+    }
 
-        function it_can_run_on_minimum_version() {
-            $this->does_it_meet_required_php_version( '5.4.0' )->shouldReturn( true );
-        }
+    function it_can_run_on_minimum_version() {
+        $this->does_it_meet_required_php_version( '5.4.0' )->shouldReturn( true );
+    }
 
-        function it_passes_the_recommended_version() {
-            $this->does_it_meet_recommended_php_version( '5.3.0' )->shouldReturn( true );
-        }
+    function it_passes_the_recommended_version() {
+        $this->does_it_meet_recommended_php_version( '5.3.0' )->shouldReturn( true );
+    }
 
-        function it_will_not_run_on_old_version() {
-            $this->does_it_meet_required_php_version( '5.2.4' )->shouldReturn( false );
-        }
+    function it_will_not_run_on_old_version() {
+        $this->does_it_meet_required_php_version( '5.2.4' )->shouldReturn( false );
+    }
 
-        function it_fails_the_recommended_version() {
-            $this->does_it_meet_recommended_php_version( '5.2.9' )->shouldReturn( false );
-        }
+    function it_fails_the_recommended_version() {
+        $this->does_it_meet_recommended_php_version( '5.2.9' )->shouldReturn( false );
     }
 }

--- a/spec/bootstrap.php
+++ b/spec/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+function esc_url( $string ) {
+    return $string;
+}
+
+function add_action( $hook, $callback ) {
+    return true;
+}
+
+function is_admin() {
+    return true;
+}

--- a/src/Notices/Abstract.php
+++ b/src/Notices/Abstract.php
@@ -1,0 +1,19 @@
+<?php
+
+abstract class WPUP_Notice implements WPUP_Notice_Interface
+{
+	protected $version;
+	protected $plugin_name;
+	protected $url = 'http://wpupdatephp.com/update/';
+
+	public function __construct( $version, $plugin_name = NULL )
+	{
+		$this->version = $version;
+		$this->plugin_name = $plugin_name;
+	}
+
+	public function display()
+	{
+		return '<div class="error">' . $this->getNoticeText() . '</div>';
+	}
+}

--- a/src/Notices/Interface.php
+++ b/src/Notices/Interface.php
@@ -2,5 +2,5 @@
 
 interface WPUP_Notice_Interface
 {
-	protected function getNoticeText();
+	public function getNoticeText();
 }

--- a/src/Notices/Interface.php
+++ b/src/Notices/Interface.php
@@ -1,0 +1,6 @@
+<?php
+
+interface WPUP_Notice_Interface
+{
+	protected function getNoticeText();
+}

--- a/src/Notices/Minimum.php
+++ b/src/Notices/Minimum.php
@@ -2,7 +2,7 @@
 
 class WPUP_Minimum_Notice extends WPUP_Notice
 {
-	protected function getNoticeText()
+	public function getNoticeText()
 	{
 		$plugin_name = $this->plugin_name ? $this->plugin_name : 'this plugin';
 

--- a/src/Notices/Minimum.php
+++ b/src/Notices/Minimum.php
@@ -1,0 +1,11 @@
+<?php
+
+class WPUP_Minimum_Notice extends WPUP_Notice
+{
+	protected function getNoticeText()
+	{
+		$plugin_name = $this->plugin_name ? $this->plugin_name : 'this plugin';
+
+		return 'Unfortunately, ' . $plugin_name . ' cannot run on PHP versions older than ' . $this->version . '. Read more information about <a href="' . esc_url( $this->url ) . '">how you can update</a>.
+	}
+}

--- a/src/Notices/Minimum.php
+++ b/src/Notices/Minimum.php
@@ -6,6 +6,6 @@ class WPUP_Minimum_Notice extends WPUP_Notice
 	{
 		$plugin_name = $this->plugin_name ? $this->plugin_name : 'this plugin';
 
-		return 'Unfortunately, ' . $plugin_name . ' cannot run on PHP versions older than ' . $this->version . '. Read more information about <a href="' . esc_url( $this->url ) . '">how you can update</a>.
+		return 'Unfortunately, ' . $plugin_name . ' cannot run on PHP versions older than ' . $this->version . '. Read more information about <a href="' . esc_url( $this->url ) . '">how you can update</a>.';
 	}
 }

--- a/src/Notices/Recommended.php
+++ b/src/Notices/Recommended.php
@@ -2,7 +2,7 @@
 
 class WPUP_Recommended_Notice extends WPUP_Notice
 {
-	protected function getNoticeText()
+	public function getNoticeText()
 	{
 		$plugin_name = $this->plugin_name ? $this->plugin_name : 'This plugin';
 

--- a/src/Notices/Recommended.php
+++ b/src/Notices/Recommended.php
@@ -1,0 +1,11 @@
+<?php
+
+class WPUP_Recommended_Notice extends WPUP_Notice
+{
+	protected function getNoticeText()
+	{
+		$plugin_name = $this->plugin_name ? $this->plugin_name : 'This plugin';
+
+		return $plugin_name . ' recommends a PHP version higher than ' . $this->version . '. Read more information about <a href="' . esc_url( $this->url ) . '">how you can update</a>.';
+	}
+}

--- a/src/WPUpdatePhp.php
+++ b/src/WPUpdatePhp.php
@@ -52,7 +52,8 @@ class WPUpdatePhp {
 			return true;
 		}
 
-		$this->load_version_notice( array( $this, 'minimum_admin_notice' ) );
+		$notice = new WPUP_Minimum_Notice( $this->minimum_version, $this->plugin_name );
+		$this->load_version_notice( array( $notice, 'display' ) );
 		return false;
 	}
 
@@ -69,7 +70,8 @@ class WPUpdatePhp {
 			return true;
 		}
 
-		$this->load_version_notice( array( $this, 'recommended_admin_notice' ) );
+		$notice = new WPUP_Recommended_Notice( $this->recommended_version, $this->plugin_name );
+		$this->load_version_notice( array( $notice, 'display' ) );
 		return false;
 	}
 
@@ -94,55 +96,5 @@ class WPUpdatePhp {
 			add_action( 'admin_notices', $callback );
 			add_action( 'network_admin_notices', $callback );
 		}
-	}
-
-	/**
-	 * Return the string to be shown in the admin notice.
-	 *
-	 * This is based on the level (`recommended` or default `minimum`) of the
-	 * notice. This will also add the plugin name to the notice string, if set.
-	 *
-	 * @param string $level Optional. Admin notice level, `recommended` or `minimum`.
-	 *                      Default is `minimum`.
-	 * @return string
-	 */
-	public function get_admin_notice( $level = 'minimum' ) {
-		if ( 'recommended' === $level ) {
-			if ( ! empty( $this->plugin_name ) ) {
-				return '<p>' . $this->plugin_name . ' recommends a PHP version higher than ' . $this->recommended_version . '. Read more information about <a href="http://www.wpupdatephp.com/update/">how you can update</a>.</p>';
-			} else {
-				return '<p>This plugin recommends a PHP version higher than ' . $this->recommended_version . '. Read more information about <a href="http://www.wpupdatephp.com/update/">how you can update</a>.</p>';
-			}
-		}
-
-		if ( ! empty( $this->plugin_name ) ) {
-			return '<p>Unfortunately, ' . $this->plugin_name . ' cannot run on PHP versions older than ' . $this->minimum_version . '. Read more information about <a href="http://www.wpupdatephp.com/update/">how you can update</a>.</p>';
-		} else {
-			return '<p>Unfortunately, this plugin cannot run on PHP versions older than ' . $this->minimum_version . '. Read more information about <a href="http://www.wpupdatephp.com/update/">how you can update</a>.</p>';
-		}
-	}
-
-	/**
-	 * Method hooked into admin_notices when minimum required PHP version is not
-	 * available to show this in a notice.
-	 *
-	 * @hook admin_notices
-	 */
-	public function minimum_admin_notice() {
-		echo '<div class="error">';
-		echo $this->get_admin_notice( 'minimum' );
-		echo '</div>';
-	}
-
-	/**
-	 * Method hooked into admin_notices when recommended PHP version is not
-	 * available to show this in a notice.
-	 *
-	 * @hook admin_notices
-	 */
-	public function recommended_admin_notice() {
-		echo '<div class="error">';
-		echo $this->get_admin_notice( 'recommended' );
-		echo '</div>';
 	}
 }


### PR DESCRIPTION
Now that [Mozart](https://github.com/coenjacobs/mozart) is capable of bundling libraries like this in a way that minimizes the risk of collisions like #37, I feel much more comfortable to split the library up in multiple classes. Notices is a nice first step - thanks for the suggestion @GaryJones in #35!